### PR TITLE
sort linker input file list

### DIFF
--- a/makefile
+++ b/makefile
@@ -70,7 +70,7 @@ HEADER_DIRS = $(MODULES) $(COMMON_DIR) $(CIMOM_ROOT) $(CIMOM_ROOT)/wmi $(CIMOM_R
 
 CPP_OBJS = $(patsubst $(SRC_DIR)/%.cpp,%.o,$(CPP_SRC))
 C_OBJS = $(patsubst $(SRC_DIR)/%.c,%.o,$(C_SRC))
-OBJS = $(C_OBJS) $(CPP_OBJS)
+OBJS = $(sort $(C_OBJS) $(CPP_OBJS))
 # add the resource file on windows
 ifdef BUILD_WINDOWS
 	OBJS += framework_resources.o


### PR DESCRIPTION
so that libinvm-cim.so.1.0.0 is built in a reproducible way
in spite of indeterministic filesystem readdir order
that comes in via make's wildcard function
and influences ordering of functions in the linker output

See https://reproducible-builds.org/ for why this is good.